### PR TITLE
[feature] timer 커맨드 추가

### DIFF
--- a/src/commands/Timer.ts
+++ b/src/commands/Timer.ts
@@ -44,8 +44,13 @@ class Timer extends BaseCommand {
     }
 
     private stopTimer(message: Message, timerInfo: StopTimerCommand) {
-        TimeService.clearTimer(message.author.username, timerInfo.timerName);
-        message.reply(`${this.formatTimerName(timerInfo.timerName)}타이머를 종료했습니다.`);
+        const timerCleared = TimeService.clearTimer(message.author.username, timerInfo.timerName);
+
+        if (timerCleared) {
+            message.reply(`${this.formatTimerName(timerInfo.timerName)}타이머를 종료했습니다.`);
+        } else {
+            message.reply('그런 타이머는 실행된 적이 없습니다.');
+        }
     }
 
     private parseMessage(content: string): TimerCommands {

--- a/src/commands/Timer.ts
+++ b/src/commands/Timer.ts
@@ -1,0 +1,85 @@
+import BaseCommand from './base/BaseCommand';
+import TimeService from '@services/TimeService';
+import type {Message} from 'discord.js';
+import NotSupportCommandError from '@errors/NotSupportCommandError';
+
+type TimerCommands = {
+    type: string;
+    timerName?: string;
+    timeout?: number;
+}
+
+type StartTimerCommand = Required<Pick<TimerCommands, 'timeout'>> & Omit<TimerCommands, 'type'>;
+type StopTimerCommand = Omit<TimerCommands, 'type' | 'timeout'>;
+
+class Timer extends BaseCommand {
+    command = 'timer';
+    private supportSubCommands = ['start', 'stop'];
+
+    /*
+     * !timer name timeout || !timer timeout (name=default)
+     */
+    async execute(message: Message): Promise<void> {
+        const timeInfo = this.parseMessage(message.content);
+        switch (timeInfo.type) {
+            case 'start': {
+                this.startTimer(message, timeInfo as StartTimerCommand);
+                break;
+            }
+            case 'stop': {
+                this.stopTimer(message, timeInfo);
+            }
+        }
+    }
+
+    private startTimer(message: Message, timerInfo: StartTimerCommand) {
+        TimeService.addTimer({
+            username: message.author.username,
+            timerName: timerInfo.timerName,
+            timeout: timerInfo.timeout
+        }, () => {
+            message.reply(`${this.formatTimerName(timerInfo.timerName)}시간이 되었습니당!`);
+        });
+        message.reply(`${this.formatTimerName(timerInfo.timerName)}타이머를 시작합니다!`);
+    }
+
+    private stopTimer(message: Message, timerInfo: StopTimerCommand) {
+        TimeService.clearTimer(message.author.username, timerInfo.timerName);
+        message.reply(`${this.formatTimerName(timerInfo.timerName)}타이머를 종료했습니다.`);
+    }
+
+    private parseMessage(content: string): TimerCommands {
+        const [, type, arg1, arg2] = content.split(' ');
+        const result: Partial<TimerCommands> = {};
+
+        if (!this.supportSubCommands.includes(type)) {
+            throw new NotSupportCommandError({
+                support: this.supportSubCommands,
+            });
+        }
+        result.type = type;
+
+        const numArg1 = parseInt(arg1); // timerName or timeout
+        const numArg2 = parseInt(arg2); // timeout if arg1 is timerName
+        if (Number.isNaN(numArg1)) {
+            // arg1 이 문자열이라면, arg2 는 숫자만 가능하다.
+            result.timerName = arg1;
+
+            if (type === 'start' && !Number.isNaN(numArg2) && numArg2 >= 0) {
+                // arg2 는 type 이 start 일 경우에만 적용된다.
+                result.timeout = numArg2;
+            }
+        } else if (numArg1 >= 0) {
+            // arg1 이 숫자라면, 이 값은 timeout 이다.
+            result.timeout = numArg1;
+        }
+
+        return result as TimerCommands;
+    }
+
+    private formatTimerName(timerName?: string) {
+        return timerName ? `${timerName} ` : '';
+    }
+}
+
+export default new Timer();

--- a/src/errors/InvalidParameterError.ts
+++ b/src/errors/InvalidParameterError.ts
@@ -1,0 +1,5 @@
+export default class InvalidParameterError extends Error {
+    constructor(message = 'Invalid Parameter') {
+        super(message);
+    }
+}

--- a/src/errors/NotSupportCommandError.ts
+++ b/src/errors/NotSupportCommandError.ts
@@ -1,0 +1,14 @@
+export default class NotSupportCommandError extends Error {
+    constructor(payload?: { message?: string; support?: string[] }) {
+        const {
+            message = 'Not support command',
+            support,
+        } = payload || {};
+
+        const supportCommandMessage = support?.reduce((result, current) => {
+            return `${result}${current}, `;
+        }, `${message}\nSupport Commands below\n`);
+
+        super(supportCommandMessage || message);
+    }
+}

--- a/src/services/TimeService.ts
+++ b/src/services/TimeService.ts
@@ -1,0 +1,26 @@
+type TimerInfo = {
+    username: string;
+    timeout: number;
+    timerName?: string;
+}
+
+const SECOND = 1000;
+
+export default new class TimeService {
+    private timers: {[username: string]: {[timerName: string]: NodeJS.Timeout }} = {};
+
+    addTimer(info: TimerInfo, callback: () => void) {
+        const {
+            username, timeout, timerName = 'default'
+        } = info;
+
+        !this.timers[username] && (this.timers[username] = {});
+        this.timers[username][timerName] = setTimeout(callback, timeout * SECOND);
+    }
+
+    clearTimer(username: string, timerName = 'default') {
+        !this.timers[username] && (this.timers[username] = {});
+        const targetTimer = this.timers[username][timerName];
+        targetTimer && clearTimeout(targetTimer);
+    }
+}();

--- a/src/services/TimeService.ts
+++ b/src/services/TimeService.ts
@@ -15,12 +15,23 @@ export default new class TimeService {
         } = info;
 
         !this.timers[username] && (this.timers[username] = {});
+        this.clearTimer(username, timerName);
         this.timers[username][timerName] = setTimeout(callback, timeout * SECOND);
     }
 
-    clearTimer(username: string, timerName = 'default') {
+    /**
+     * @return 타이머가 존재했는지에 대한 여부
+     */
+    clearTimer(username: string, timerName = 'default'): boolean {
         !this.timers[username] && (this.timers[username] = {});
         const targetTimer = this.timers[username][timerName];
-        targetTimer && clearTimeout(targetTimer);
+
+        if (targetTimer) {
+            clearTimeout(targetTimer);
+            delete this.timers[username][timerName];
+            return true;
+        } else {
+            return false;
+        }
     }
 }();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,9 @@
       "*": ["node_modules/*"],
       "@validators/*": ["validators/*"],
       "@commands/*": ["commands/*"],
-      "@core/*": ["core/*"]
+      "@core/*": ["core/*"],
+      "@services/*": ["services/*"],
+      "@errors/*": ["errors/*"]
     },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [


### PR DESCRIPTION
- 타이머는 각 유저별로 동작
- 타이머는 각 유저별로 타이머 별 이름을 부여할 수 있음 (여러개의 타이머 동시 수행 가능)
  - 이름을 부여하지 않으면 default 라는 이름으로 내부적으로 동작
- 타이머 정지 기능
- 타이머는 초단위로 입력가능 (추후 개선여지)

---

[봐줄만한 위치]

- src/commands/Timer.ts#L56 디코 문자열을 커맨드에 쓰기위해 파싱하는 로직인데, 별로인것 같기도하고..
  - !timer [start|stop] [timerName|숫자] [앞이 timerName 인 경우 숫자] 의 규칙을 파싱함
- 커스텀 에러의 운용방식 나쁘지 않은가? instanceof 를 통해 분기할 수 있게 만들고 추후 모아보기를 쉽게하기 위해 만듬
- 서비스 레이어의 추가
  - 커맨드는 받은 명령에 대한 컨트롤러 페이즈라고 생각하고, 이 명령을 파싱해 서비스 레이어로 돌아간다고 고려했음
  - 디스코드의 컨트롤러 -> 서비스는 index -> core // 명령어단위의 컨트롤러 -> 서비스는 command -> service
  - 구조상 뭔가 추후 결합도가 높아지거나 유지보수상 문제가 있을만한 포인트가 있을지?